### PR TITLE
fix(core): scope register-button hide to Apple store-review builds

### DIFF
--- a/flutter/packages/growerp_core/lib/src/domains/common/views/home_form.dart
+++ b/flutter/packages/growerp_core/lib/src/domains/common/views/home_form.dart
@@ -12,6 +12,7 @@
  * limitations under the License.
  */
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:global_configuration/global_configuration.dart';
@@ -330,11 +331,14 @@ class HomeFormState extends State<HomeForm> with TickerProviderStateMixin {
                                     },
                                   ),
                                   const SizedBox(height: 50),
+                                  // hide registration in store review builds:
+                                  // they run against the test backend
                                   if (applicationId != 'AppSupport' &&
-                                      !(applicationId == 'AppHotel' &&
+                                      !(kReleaseMode &&
                                           GlobalConfiguration().get("test") ==
                                               true &&
-                                          Platform.isMacOS))
+                                          (Platform.isIOS ||
+                                              Platform.isMacOS)))
                                     _buildPremiumButton(
                                       context: context,
                                       key: const Key('newUserButton'),


### PR DESCRIPTION
## Problem

The register button guard on the home screen fired only for `AppHotel` on macOS:

```dart
if (applicationId != 'AppSupport' &&
    !(applicationId == 'AppHotel' &&
        GlobalConfiguration().get("test") == true &&
        Platform.isMacOS))
```

Two issues:

- iOS was not covered at all, and only one app was, though the intent (commit `89d3ac64`, "Automated submission to the application stores") was to keep self-registration out of store-review builds generally.
- `getBackendUrlOverride()` sets `test = true` in **any** debug build that gets no backend override, so the guard also fired during local development.

## Change

`flutter/packages/growerp_core/lib/src/domains/common/views/home_form.dart`

```dart
if (applicationId != 'AppSupport' &&
    !(kReleaseMode &&
        GlobalConfiguration().get("test") == true &&
        (Platform.isIOS || Platform.isMacOS)))
```

- Applies to iOS and macOS, for every app (`AppSupport` exclusion unchanged).
- `kReleaseMode` limits the hide to store-review builds, so debug runs and `-d macos` integration tests still find `Key('newUserButton')` (`registration_login_test.dart`, `evaluation_test.dart`, `auth_test.dart`, `common_test.dart`).
- Adds the `package:flutter/foundation.dart` import.

The TEST banner suppression on Apple platforms is deliberately left untouched.

## Verification

- `dart analyze` on the changed file: clean.
- Not run: full `melos analyze`, integration suite, and the Mac release-vs-debug check (needs Mac hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)